### PR TITLE
changed method to getAsFiltree() in getDefaultClasspath() and getPlug…

### DIFF
--- a/src/main/groovy/com/github/eerohele/DitaOtSetupTask.groovy
+++ b/src/main/groovy/com/github/eerohele/DitaOtSetupTask.groovy
@@ -29,11 +29,11 @@ class DitaOtSetupTask extends DefaultTask {
     }
 
     FileTree getDefaultClasspath(Project project) {
-        Classpath.forProject(project).asType(FileTree)
+        Classpath.forProject(project).getAsFileTree()
     }
 
     FileTree getPluginClasspath(Project project) {
-        Classpath.pluginClasspath(project).asType(FileTree)
+        Classpath.pluginClasspath(project).getAsFileTree()
     }
 
     @TaskAction


### PR DESCRIPTION
I use this snippet in my build 
```
classpath  getDefaultClasspath(project).matching {
			exclude('**/saxon*.jar')
	} + fileTree(dir:'ditaot/plugins/com.lgroup.base/libs',include:'*.jar')
```

With Gradle 4.8 and `--warning-mode=all` I get this message:
```
Do not cast FileCollection to FileTree. This has been deprecated and is scheduled to be removed in Gradle 5.0. Call getAsFileTree() instead.
        at build_8yn9e5e7cbhnhey8x3wx5b9g7$_run_closure4.doCall(C:\workspace\L2-head\gradleBuild\exechelp.new\build.gradle:38)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

after some investigation I found that the DitaOtSetupTask.groovy uses this code: 
```
FileTree getPluginClasspath(Project project) {
        Classpath.pluginClasspath(project).asType(FileTree)
 }
```

I replaced `asType(FileTree)` with `getAsFileTree()`.