### PR TITLE
Fix link to installation topic in DITA-OT docs

### DIFF
--- a/src/main/dita/install.dita
+++ b/src/main/dita/install.dita
@@ -74,7 +74,7 @@ dita {
   </taskbody>
 
   <related-links scope="external" format="html">
-    <link href="http://www.dita-ot.org/dev/getting-started/installing-client.html">
+    <link href="https://www.dita-ot.org/dev/topics/installing-client.html">
       <linktext>Installing DITA Open Toolkit</linktext>
     </link>
 


### PR DESCRIPTION
This topic moved when the DITA-OT docs were refactored for the 3.0 release.

I have not changed the `docs/index.html` output file, figuring that would be better regenerated via the build process for the GitHub Pages site, but I'm not entirely sure how that works here.

If you'd rather not re-run the build process at this point, I can push another commit to manually update the output file.